### PR TITLE
Revert "Use correct mechanism to disable auto-sizes CSS fix"

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -22,7 +22,7 @@ if (defined('WP_DEBUG') && WP_DEBUG) {
     remove_action('wp_head', 'rsd_link');
     remove_action('wp_head', 'wp_oembed_add_discovery_links');
     remove_action('wp_head', 'wp_custom_css_cb', 101);
-    add_filter('wp_img_tag_add_auto_sizes', '__return_false');
+    remove_action('wp_head', 'wp_print_auto_sizes_contain_css_fix', 1);
 
     // Disable emojis
     remove_action('wp_head', 'print_emoji_detection_script', 7);


### PR DESCRIPTION
Reverts szepeviktor/zero-bytes-theme#3

I was incorrect to suggest the use of the filter. See https://github.com/WordPress/wordpress-develop/pull/8954#issuecomment-3364076685.